### PR TITLE
Fixed issues with the config utility

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -980,7 +980,7 @@ void apply_config(void) {
     cputs("your screen may flicker.");
 
     // Ask card to reboot.
-    cfg_cmd0("RB");
+    cfg_cmd0("Rb");
 
     while(timeout--);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -138,6 +138,7 @@ menu_strings_t font_strings[40] = {
     { "26: Custom          " },
     { "27: Custom          " },
 };
+#define FONT_COUNT (sizeof(font_strings)/sizeof(menu_strings_t))
 
 menu_strings_t monochrome_strings[9] = {
     { "Disabled" },
@@ -451,7 +452,9 @@ int parse_config() {
             jd_port = ptr[i+1];
             break;
         case CFGTOKEN_FONT_00:
-            default_font = (ptr[i] >> 16) & 0x2F;
+            default_font = (ptr[i] >> 16) & 0x3F;
+            if (default_font >= FONT_COUNT)
+	            default_font = 0;
             break;
         case CFGTOKEN_MONO_00:
             mono_palette = (ptr[i] >> 20) & 0xF;
@@ -488,7 +491,9 @@ int build_config(uint32_t rev) {
     ptr[i++] = NEWCONFIG_MAGIC;
     ptr[i++] = CFGTOKEN_REVISION | ((rev & 0xff) << 16);
 
-    ptr[i++] = CFGTOKEN_FONT_00 | ((((uint32_t)default_font) & 0x2F) << 20);
+    if (default_font >= FONT_COUNT)
+	    default_font = 0;
+    ptr[i++] = CFGTOKEN_FONT_00 | ((((uint32_t)default_font) & 0x3F) << 16);
     if(mono_palette) {
         ptr[i++] = CFGTOKEN_MONO_80 | ((((uint32_t)mono_palette-1) & 0xF) << 20);
     } else {
@@ -1533,7 +1538,7 @@ int video_menu_action(int action) {
     int edit_color = -1;
     switch(action) {
         case 0:
-            default_font = list_menu("Video Settings", " Default Font ", font_strings, (sizeof(font_strings)/sizeof(menu_strings_t))-1, default_font, default_font);
+            default_font = list_menu("Video Settings", " Default Font ", font_strings, FONT_COUNT-1, default_font, default_font);
             return 2;
         case 1:
             mono_palette = list_menu("Video Settings", " Monochrome Mode ", monochrome_strings, (sizeof(monochrome_strings)/sizeof(menu_strings_t))-1, mono_palette, mono_palette);


### PR DESCRIPTION
See commit comments:

-  Fixed reboot after configuration.

    The utility issued a "RB" command. This is not understood by the firmware,
    so the PICO did not reboot but reported an error.
    The reboot is triggerd by "Rb" (b vs B).

- Fixed font configuration.

    In CFGTOKEN_FONT_00 the value of the selected font must be shifted by
    16 bits - not by 20 bits. Therefore, selection of any font did not work.
    
    Also, the firmware supports 40 font slots (00-2F). However, 0x2F is not
    a (2^n)-1 value, so it cannot be used as a bit mask (e.g. fonts 0x10-0x1F
    could not be selected - since bit 4 was always cleared by the 0x2F bit mask).
